### PR TITLE
FTP-11 Added PBSZ command

### DIFF
--- a/Commands/Command.go
+++ b/Commands/Command.go
@@ -59,7 +59,7 @@ func GetCommandMap(cs *Connection.Status, config Configuration.FTPConfig) map[st
 		"CONF": NotImplemented{},
 		"ENC":  NotImplemented{},
 		"MIC":  NotImplemented{},
-		"PBSZ": NotImplemented{},
+		"PBSZ": PBSZ{cs: cs},
 		"PROT": NotImplemented{},
 
 		// RFC-2389 Command Set

--- a/Commands/PBSZ.go
+++ b/Commands/PBSZ.go
@@ -1,0 +1,29 @@
+package Commands
+
+import (
+	"FTPserver/Connection"
+	"FTPserver/Replies"
+	"math"
+	"strconv"
+)
+
+type PBSZ struct {
+	cs *Connection.Status
+}
+
+func (cmd PBSZ) Execute(args string) Replies.FTPReply {
+	// only TLS, a streaming system, is supported so only size 0 will work
+	if !cmd.cs.Security.IsSecure {
+		return Replies.CreateReplyBadCommandSequence()
+	}
+	size, err := strconv.Atoi(args)
+	if err != nil || size < 0 || size > math.MaxInt32 {
+		return Replies.CreateReplySyntaxErrorInParameters()
+	}
+	cmd.cs.Security.ProtectedBSize = 0
+	reply := Replies.CreateReplyCommandOkay()
+	if size > 0 {
+		reply.Message = "PBSZ=0"
+	}
+	return reply
+}

--- a/Connection/Security.go
+++ b/Connection/Security.go
@@ -14,4 +14,5 @@ type Security struct {
 	Config            *tls.Config
 	CertFile          string
 	KeyFile           string
+	ProtectedBSize    int
 }

--- a/Server/connection.go
+++ b/Server/connection.go
@@ -99,6 +99,7 @@ func connectionHandle(connectionSocket net.Conn, config Configuration.FTPConfig)
 			},
 			Rand: rand.Reader,
 		},
+		ProtectedBSize: -1,
 	}
 	connectionStatus = Connection.Status{
 		Connected:          false,


### PR DESCRIPTION
Added the Protected Buffer Size command. This is only useful for TLS security, and so the only useful size is 0. It should respond appropriately to any incorrectly formatted size, or any correctly formatted size with something other than 0 (by informing that it is in fact using 0).