### PR TITLE
FTP-12 Added the PROT command, rewrote all data connection handling

### DIFF
--- a/Commands/Command.go
+++ b/Commands/Command.go
@@ -60,7 +60,7 @@ func GetCommandMap(cs *Connection.Status, config Configuration.FTPConfig) map[st
 		"ENC":  NotImplemented{},
 		"MIC":  NotImplemented{},
 		"PBSZ": PBSZ{cs: cs},
-		"PROT": NotImplemented{},
+		"PROT": PROT{cs: cs},
 
 		// RFC-2389 Command Set
 		"FEAT": NotImplemented{},

--- a/Commands/LPRT.go
+++ b/Commands/LPRT.go
@@ -44,67 +44,77 @@ func (af AddressFamily) String() string {
 	}
 }
 
-func IPv6LPRTExecute(segments []string, cs *Connection.Status) Replies.FTPReply {
-	getSegments := func(strings []string, expectedLength uint8) []uint8 {
-		length, err := strconv.ParseUint(strings[0], 10, 8)
-		if err != nil || uint8(length) != expectedLength || len(strings[1:]) != int(length) {
-			return nil
-		}
-		segments := make([]uint8, length)
-		for i, octet := range strings[1:] {
-			segment, err := strconv.ParseUint(octet, 10, 8)
-			if err != nil {
+func (cmd LPRT) Execute(args string) Replies.FTPReply {
+	IPv6LPRTExecute := func(segments []string, cs *Connection.Status) Replies.FTPReply {
+		getSegments := func(strings []string, expectedLength uint8) []uint8 {
+			length, err := strconv.ParseUint(strings[0], 10, 8)
+			if err != nil || uint8(length) != expectedLength || len(strings[1:]) != int(length) {
 				return nil
 			}
-			segments[i] = uint8(segment)
+			segments := make([]uint8, length)
+			for i, octet := range strings[1:] {
+				segment, err := strconv.ParseUint(octet, 10, 8)
+				if err != nil {
+					return nil
+				}
+				segments[i] = uint8(segment)
+			}
+			return segments
 		}
-		return segments
-	}
 
-	getIP6Addr := func(addressSegmentStrings []string) net.IP {
-		as := getSegments(addressSegmentStrings, 16)
-		if as == nil {
-			return net.IPv6unspecified
+		getIP6Addr := func(addressSegmentStrings []string) net.IP {
+			as := getSegments(addressSegmentStrings, 16)
+			if as == nil {
+				return net.IPv6unspecified
+			}
+			return net.IP{as[0], as[1], as[2], as[3], as[4], as[5], as[6], as[7],
+				as[8], as[9], as[10], as[11], as[12], as[13], as[14], as[15]}
 		}
-		return net.IP{as[0], as[1], as[2], as[3], as[4], as[5], as[6], as[7],
-			as[8], as[9], as[10], as[11], as[12], as[13], as[14], as[15]}
-	}
 
-	getIP6Port := func(portSegmentStrings []string) uint16 {
-		ps := getSegments(portSegmentStrings, 2)
-		if ps == nil {
-			return 0
+		getIP6Port := func(portSegmentStrings []string) uint16 {
+			ps := getSegments(portSegmentStrings, 2)
+			if ps == nil {
+				return 0
+			}
+			return (uint16(ps[0]) * 256) + uint16(ps[1])
 		}
-		return (uint16(ps[0]) * 256) + uint16(ps[1])
+
+		ip6Addr := getIP6Addr(segments[0:17])
+		if ip6Addr.IsUnspecified() {
+			return Replies.CreateReplySyntaxErrorInParameters()
+		}
+
+		ip6Port := getIP6Port(segments[17:20])
+		if ip6Port == 0 {
+			return Replies.CreateReplySyntaxErrorInParameters()
+		}
+
+		remoteAddr := fmt.Sprintf("[%v]:%v", ip6Addr, ip6Port)
+		localIP := strings.Split(cs.CommandConnection.LocalAddr().String(), ":")
+		localPort, _ := strconv.Atoi(localIP[len(localIP)-1])
+		localIPAddress := cs.CommandConnection.LocalAddr().(*net.TCPAddr).IP
+		localAddr := fmt.Sprintf("[%v]:%v", localIPAddress, (uint16)(localPort-1))
+
+		dataConnection := Connection.DataConnection{
+			TransferType:    Connection.TransferType(Connection.Active),
+			Protocol:        "tcp6",
+			LocalAddress:    localAddr,
+			RemoteAddress:   remoteAddr,
+			Connection:      nil,
+			PassivePort:     0,
+			PassiveListener: nil,
+			Security:        cs.Security,
+			IsSetup:         false,
+		}
+		err := dataConnection.Setup()
+		if err != nil {
+			_, _ = fmt.Fprintf(os.Stderr, "error opening data connection: %v\n", err)
+			return Replies.CreateReplyCantOpenDataConnection()
+		}
+		cs.DataConnection = dataConnection
+		return Replies.CreateReplyCommandOkay()
 	}
 
-	ip6Addr := getIP6Addr(segments[0:17])
-	if ip6Addr.IsUnspecified() {
-		return Replies.CreateReplySyntaxErrorInParameters()
-	}
-
-	ip6Port := getIP6Port(segments[17:20])
-	if ip6Port == 0 {
-		return Replies.CreateReplySyntaxErrorInParameters()
-	}
-
-	destinationSocket := fmt.Sprintf("[%v]:%v", ip6Addr, ip6Port)
-	localIP := strings.Split(cs.CommandConnection.LocalAddr().String(), ":")
-	localPort, _ := strconv.Atoi(localIP[len(localIP)-1])
-	localIPAddress := cs.CommandConnection.LocalAddr().(*net.TCPAddr).IP
-	localSocket := fmt.Sprintf("[%v]:%v", localIPAddress, (uint16)(localPort-1))
-	local, _ := net.ResolveTCPAddr("tcp6", localSocket)
-	remote, _ := net.ResolveTCPAddr("tcp6", destinationSocket)
-	conn, err := net.DialTCP("tcp6", local, remote)
-	if err != nil {
-		_, _ = fmt.Fprintf(os.Stderr, "error opening data connection: %v\n", err)
-		return Replies.CreateReplyCantOpenDataConnection()
-	}
-	cs.DataConnect(conn)
-	return Replies.CreateReplyCommandOkay()
-}
-
-func (cmd LPRT) Execute(args string) Replies.FTPReply {
 	if cmd.cs.EPSVAll {
 		return Replies.CreateReplyBadCommandSequence()
 	}

--- a/Commands/PROT.go
+++ b/Commands/PROT.go
@@ -1,0 +1,41 @@
+package Commands
+
+import (
+	"FTPserver/Connection"
+	"FTPserver/Replies"
+)
+
+type PROT struct {
+	cs *Connection.Status
+}
+
+func (cmd PROT) Execute(args string) Replies.FTPReply {
+	var dataLevelProtection Connection.DataChannelProtectionLevel
+	switch args {
+	case "C":
+		dataLevelProtection = Connection.DataChannelProtectionLevel(Connection.Clear)
+	case "P":
+		dataLevelProtection = Connection.DataChannelProtectionLevel(Connection.Private)
+	case "S":
+		dataLevelProtection = Connection.DataChannelProtectionLevel(Connection.Safe)
+	case "E":
+		dataLevelProtection = Connection.DataChannelProtectionLevel(Connection.Confidential)
+	default:
+		return Replies.CreateReplyCommandNotImplementedForParameter()
+	}
+	isSupported := false
+	for _, b := range cmd.cs.Security.SecurityMechanism.SupportedProtections() {
+		if dataLevelProtection == b {
+			isSupported = true
+			break
+		}
+	}
+	if !isSupported {
+		return Replies.CreateReplyRequestedPROTNotSupported()
+	}
+	if cmd.cs.Security.ProtectedBSize == -1 {
+		return Replies.CreateReplyBadCommandSequence()
+	}
+	cmd.cs.Security.ProtectionLevel = dataLevelProtection
+	return Replies.CreateReplyCommandOkay()
+}

--- a/Connection/ConnectionStatus.go
+++ b/Connection/ConnectionStatus.go
@@ -49,7 +49,7 @@ type Status struct {
 	TextProto          *textproto.Conn
 	StandardConnection net.Conn
 	DataConnected      bool
-	DataConnection     net.Conn
+	DataConnection     DataConnection
 	Remote             string
 	Authenticated      bool
 	Anonymous          bool
@@ -79,17 +79,13 @@ func (cs *Status) Disconnect() {
 	cs.Connected = false
 }
 
-func (cs *Status) DataConnect(conn net.Conn) {
+func (cs *Status) DataConnect() {
 	cs.DataConnected = true
-	cs.DataConnection = conn
 }
 
 func (cs *Status) DataDisconnect() {
-	if cs.DataConnection != nil {
-		cs.DataConnection.Close()
-	}
+	cs.DataConnection.Close()
 	cs.DataConnected = false
-	cs.DataConnection = nil
 }
 
 func (cs *Status) IsConnected() bool {

--- a/Connection/DataConnection.go
+++ b/Connection/DataConnection.go
@@ -1,0 +1,144 @@
+package Connection
+
+import (
+	"crypto/tls"
+	"fmt"
+	"io"
+	"net"
+	"os"
+)
+
+type DataConnection struct {
+	TransferType    TransferType
+	Protocol        string
+	LocalAddress    string
+	RemoteAddress   string
+	Connection      net.Conn
+	PassivePort     int
+	PassiveListener net.Listener
+	Security        Security
+	IsSetup         bool
+}
+
+type DataConnectionError struct {
+	Err string
+}
+
+func (dce *DataConnectionError) Error() string {
+	if dce == nil {
+		return "<nil>"
+	}
+	return fmt.Sprintf("DataConnectionError: %v", dce.Err)
+}
+
+func (dc *DataConnection) Setup() error {
+	ActiveSetup := func() error {
+		if dc.LocalAddress == "" {
+			return &DataConnectionError{Err: "Local address not set for Active Connection"}
+		}
+		dc.IsSetup = true
+		return nil
+	}
+	PassiveSetup := func() error {
+		if dc.LocalAddress == "" {
+			return &DataConnectionError{Err: "Local address not set for Active Connection"}
+		}
+		listenSocket, err := net.Listen(dc.Protocol, dc.LocalAddress)
+		if err != nil {
+			return err
+		}
+		tcpAddr, err := net.ResolveTCPAddr(dc.Protocol, listenSocket.Addr().String())
+		if err != nil {
+			return err
+		}
+		dc.PassivePort = tcpAddr.Port
+		dc.PassiveListener = listenSocket
+		dc.IsSetup = true
+		return nil
+	}
+
+	switch dc.TransferType {
+	case TransferType(Active):
+		return ActiveSetup()
+	case TransferType(Passive):
+		return PassiveSetup()
+	}
+	return &DataConnectionError{"Invalid TransferType"}
+}
+
+func (dc *DataConnection) FinishSetup() error {
+	ActiveFinishSetup := func() error {
+		local, _ := net.ResolveTCPAddr(dc.Protocol, dc.LocalAddress)
+		remote, _ := net.ResolveTCPAddr(dc.Protocol, dc.RemoteAddress)
+		connection, err := net.DialTCP(dc.Protocol, local, remote)
+		if err != nil {
+			return err
+		}
+		if dc.Security.IsSecure {
+			dc.Connection = tls.Server(connection, dc.Security.Config)
+		} else {
+			dc.Connection = connection
+		}
+		return nil
+	}
+
+	PassiveFinishSetup := func() error {
+		connection, err := dc.PassiveListener.Accept()
+		if err != nil {
+			return err
+		}
+		err = dc.PassiveListener.Close()
+		if err != nil {
+			return err
+		}
+		if dc.Security.IsSecure && dc.Security.ProtectionLevel == DataChannelProtectionLevel(Private) {
+			dc.Connection = tls.Server(connection, dc.Security.Config)
+		} else {
+			dc.Connection = connection
+		}
+		return nil
+	}
+
+	if !dc.IsSetup {
+		return &DataConnectionError{Err: "DataConnection has not been setup"}
+	}
+
+	switch dc.TransferType {
+	case TransferType(Active):
+		return ActiveFinishSetup()
+	case TransferType(Passive):
+		return PassiveFinishSetup()
+	}
+
+	return &DataConnectionError{Err: "Invalid TransferType"}
+}
+
+func (dc DataConnection) Send(data string) (int, error) {
+	return dc.Connection.Write([]byte(data))
+}
+
+func (dc DataConnection) Receive() (string, error) {
+	var buffer []byte
+	_, err := dc.Connection.Read(buffer)
+	if err != nil {
+		return "", err
+	}
+	return string(buffer[:]), nil
+}
+
+func (dc DataConnection) CopyIn(file *os.File) (int64, error) {
+	return io.Copy(file, dc.Connection)
+}
+
+func (dc DataConnection) CopyOut(file *os.File) (int64, error) {
+	return io.Copy(dc.Connection, file)
+}
+
+func (dc DataConnection) Close() {
+	if dc.Connection != nil {
+		dc.Connection.Close()
+	}
+	if dc.PassiveListener != nil {
+		_ = dc.PassiveListener.Close()
+	}
+}

--- a/Connection/Security.go
+++ b/Connection/Security.go
@@ -6,6 +6,15 @@ import (
 	"net/textproto"
 )
 
+type DataChannelProtectionLevel int
+
+const (
+	Clear int = iota
+	Safe
+	Confidential
+	Private
+)
+
 type Security struct {
 	IsSecure          bool
 	CommandConnection net.Conn
@@ -15,4 +24,6 @@ type Security struct {
 	CertFile          string
 	KeyFile           string
 	ProtectedBSize    int
+	ProtectionLevel   DataChannelProtectionLevel
+	SecurityMechanism SecurityMechanism
 }

--- a/Connection/SecurityMechanism.go
+++ b/Connection/SecurityMechanism.go
@@ -1,0 +1,6 @@
+package Connection
+
+type SecurityMechanism interface {
+	SupportedProtections() []DataChannelProtectionLevel
+	Name() string
+}

--- a/Connection/SecurityTLS.go
+++ b/Connection/SecurityTLS.go
@@ -1,0 +1,15 @@
+package Connection
+
+type SecurityTLS struct {
+}
+
+func (sm SecurityTLS) SupportedProtections() []DataChannelProtectionLevel {
+	return []DataChannelProtectionLevel{
+		DataChannelProtectionLevel(Clear),
+		DataChannelProtectionLevel(Private),
+	}
+}
+
+func (sm SecurityTLS) Name() string {
+	return "TLS"
+}

--- a/Server/connection.go
+++ b/Server/connection.go
@@ -99,7 +99,8 @@ func connectionHandle(connectionSocket net.Conn, config Configuration.FTPConfig)
 			},
 			Rand: rand.Reader,
 		},
-		ProtectedBSize: -1,
+		ProtectedBSize:    -1,
+		SecurityMechanism: Connection.SecurityTLS{},
 	}
 	connectionStatus = Connection.Status{
 		Connected:          false,


### PR DESCRIPTION
I Added the PROT command which allows using PrivateProtection (verification/encryption) in DataChannel exchanges. As TLS only supports Private and Clear (no Confidential/Safe) Protection levels this should be sufficient. Reading the RFC about AUTH TLS (RFC 4217  https://tools.ietf.org/html/rfc4217) I realized I was technically handling my DataConnection wrong in that you only create the intention to start a data connection on the respective PORT/PASV command (and passive bind to the local socket so that you can get the listening port) And the Data Transfer commands actually are where the connection gets established (Listen/Dialed).