### PR TITLE
FTP-7 Added CCC command

### DIFF
--- a/Commands/ABOR.go
+++ b/Commands/ABOR.go
@@ -15,3 +15,7 @@ func (cmd ABOR) Execute(_ string) Replies.FTPReply {
 	}
 	return Replies.CreateReplyClosingDataConnection()
 }
+
+func (cmd ABOR) Name() string {
+	return "ABOR"
+}

--- a/Commands/ACCT.go
+++ b/Commands/ACCT.go
@@ -43,3 +43,7 @@ func (cmd ACCT) Execute(args string) Replies.FTPReply {
 	}
 	return Replies.CreateReplyNeedAccount()
 }
+
+func (cmd ACCT) Name() string {
+	return "ACCT"
+}

--- a/Commands/AUTH.go
+++ b/Commands/AUTH.go
@@ -19,7 +19,7 @@ func (cmd AUTH) Execute(args string) Replies.FTPReply {
 			return Replies.CreateReplyFailedSecurityCheck()
 		}
 		cmd.cs.SendFTPReply(Replies.CreateReplySecurityDataExchangeComplete())
-		cmd.cs.Security.IsSecure = true
+		cmd.cs.Security.SecureCommandChannel = true
 		cmd.cs.Security.CommandConnection = authConn
 		cmd.cs.CommandConnection = cmd.cs.Security.CommandConnection
 		cmd.cs.Security.TextProto = textproto.NewConn(cmd.cs.CommandConnection)
@@ -47,4 +47,8 @@ func (cmd AUTH) Execute(args string) Replies.FTPReply {
 		fn = AuthUnknownExecute
 	}
 	return fn()
+}
+
+func (cmd AUTH) Name() string {
+	return "AUTH"
 }

--- a/Commands/CCC.go
+++ b/Commands/CCC.go
@@ -1,0 +1,55 @@
+package Commands
+
+import (
+	"FTPserver/Connection"
+	"FTPserver/Replies"
+)
+
+type CCC struct {
+	cs *Connection.Status
+}
+
+// Note: absolutely no one thinks supporting CCC is a good idea. In fact the very idea of starting a channel
+// for encryption, and then backing off of that is bad idea. The problem that it solves is way better handled
+// with Passive mode. But I want a complete solution, so I am going to implement this against my better judgement.
+// I am making it configurable with a default of Forbid.
+
+// Note: I found that cURL supports CCC by using the --ftp-ssl-ccc flag. This will send the CCC and denegotiate
+// TLS on the command channel. Subsequent commands on the command channel come across unencrypted.
+
+func (cmd CCC) Execute(_ string) Replies.FTPReply {
+	if cmd.cs.Security.CCCStatus == Connection.CCCStatus(Connection.Forbid) {
+		return Replies.CreateReplySyntaxError()
+	}
+	if !cmd.cs.Security.SecureCommandChannel {
+		return Replies.CreateReplyCommandProtectionDeniedPolicy()
+	}
+
+	// From a post on Stack Overflow, no one seems to thing there is an official way to close a TLS socket and
+	// retain the underlying connection. So the solution is to keep track of the underlying socket, and signal
+	// to the TLS connection that you want to quit writing (and then force a read to get the TLS equivalent of
+	// FIN wait. Follow this up by resuming the underlying connection as the command connection.
+
+	// Additional note, the REPLY to CCC is still sent encrypted
+	cmd.cs.SendFTPReply(Replies.CreateReplyCommandOkay())
+
+	// Best code sample I could find on StackOverflow for removing the TLS from the connection without closing
+	// the underlying connection
+
+	_ = cmd.cs.Security.CommandConnection.CloseWrite()
+	buffer := make([]byte, 1)
+	_, _ = cmd.cs.Security.CommandConnection.Read(buffer)
+
+	// Reset the Command channel components
+	cmd.cs.CommandConnection = cmd.cs.StandardConnection
+	cmd.cs.TextProto = cmd.cs.StandardTextProto
+
+	cmd.cs.Security.SecureCommandChannel = false
+
+	// Already responded to the CCC so do not allow the caller to respond.
+	return Replies.CreateReplyNoAction()
+}
+
+func (cmd CCC) Name() string {
+	return "CCC"
+}

--- a/Commands/CWD.go
+++ b/Commands/CWD.go
@@ -34,3 +34,7 @@ func (cmd CWD) Execute(args string) Replies.FTPReply {
 	cmd.cs.SetPath(newDir)
 	return Replies.CreateReplyCommandOkay()
 }
+
+func (cmd CWD) Name() string {
+	return "CWD"
+}

--- a/Commands/Command.go
+++ b/Commands/Command.go
@@ -8,6 +8,7 @@ import (
 
 type FTPCommand interface {
 	Execute(args string) Replies.FTPReply
+	Name() string
 }
 
 func GetCommandMap(cs *Connection.Status, config Configuration.FTPConfig) map[string]FTPCommand {
@@ -55,7 +56,7 @@ func GetCommandMap(cs *Connection.Status, config Configuration.FTPConfig) map[st
 		// RFC-2228 Command Set
 		"ADAT": NotImplemented{},
 		"AUTH": AUTH{cs: cs},
-		"CCC":  NotImplemented{},
+		"CCC":  CCC{cs: cs},
 		"CONF": NotImplemented{},
 		"ENC":  NotImplemented{},
 		"MIC":  NotImplemented{},

--- a/Commands/DELE.go
+++ b/Commands/DELE.go
@@ -26,3 +26,7 @@ func (cmd DELE) Execute(args string) Replies.FTPReply {
 	}
 	return Replies.CreateReplyCommandOkay()
 }
+
+func (cmd DELE) Name() string {
+	return "DELE"
+}

--- a/Commands/EPRT.go
+++ b/Commands/EPRT.go
@@ -95,3 +95,7 @@ func (cmd EPRT) Execute(args string) Replies.FTPReply {
 	cmd.cs.Type = Connection.TransferType(Connection.Active)
 	return TCPExecutor(fields, protocol)
 }
+
+func (cmd EPRT) Name() string {
+	return "EPRT"
+}

--- a/Commands/EPSV.go
+++ b/Commands/EPSV.go
@@ -77,3 +77,7 @@ func (cmd EPSV) Execute(args string) Replies.FTPReply {
 	cmd.cs.DataConnection = dataConnection
 	return Replies.CreateReplyEnteringExtendedPassiveMode(cmd.cs.DataConnection.PassiveListener.Addr())
 }
+
+func (cmd EPSV) Name() string {
+	return "EPSV"
+}

--- a/Commands/HELP.go
+++ b/Commands/HELP.go
@@ -49,3 +49,7 @@ func (cmd HELP) Execute(_ string) Replies.FTPReply {
 	outStr += "\nEnd of HELP"
 	return Replies.CreateReplyHelpMessage(outStr)
 }
+
+func (cmd HELP) Name() string {
+	return "HELP"
+}

--- a/Commands/LIST.go
+++ b/Commands/LIST.go
@@ -103,3 +103,7 @@ func (cmd LIST) Execute(args string) Replies.FTPReply {
 	}
 	return Replies.CreateReplyClosingDataConnection()
 }
+
+func (cmd LIST) Name() string {
+	return "LIST"
+}

--- a/Commands/LPRT.go
+++ b/Commands/LPRT.go
@@ -131,3 +131,7 @@ func (cmd LPRT) Execute(args string) Replies.FTPReply {
 	}
 	return Replies.CreateReplySupportedAddressFamilies([]int{6})
 }
+
+func (cmd LPRT) Name() string {
+	return "LPRT"
+}

--- a/Commands/LPSV.go
+++ b/Commands/LPSV.go
@@ -64,3 +64,7 @@ func (cmd LPSV) Execute(_ string) Replies.FTPReply {
 	cmd.cs.DataConnection = dataConnection
 	return Replies.CreateReplyEnteringLongPassiveMode(cmd.String())
 }
+
+func (cmd LPSV) Name() string {
+	return "LPSV"
+}

--- a/Commands/MKD.go
+++ b/Commands/MKD.go
@@ -22,3 +22,7 @@ func (cmd MKD) Execute(args string) Replies.FTPReply {
 	}
 	return Replies.CreateReplyPathnameCreated(fullPath, true)
 }
+
+func (cmd MKD) Name() string {
+	return "MKD"
+}

--- a/Commands/MODE.go
+++ b/Commands/MODE.go
@@ -37,3 +37,7 @@ func (cmd MODE) Execute(args string) Replies.FTPReply {
 	}
 	return Replies.CreateReplyCommandNotImplementedForParameter()
 }
+
+func (cmd MODE) Name() string {
+	return "MODE"
+}

--- a/Commands/NOOP.go
+++ b/Commands/NOOP.go
@@ -5,6 +5,10 @@ import "FTPserver/Replies"
 type NOOP struct {
 }
 
-func (nop NOOP) Execute(args string) Replies.FTPReply {
+func (nop NOOP) Execute(_ string) Replies.FTPReply {
 	return Replies.CreateReplyCommandOkay()
+}
+
+func (cmd NOOP) Name() string {
+	return "NOOP"
 }

--- a/Commands/NotImplemented.go
+++ b/Commands/NotImplemented.go
@@ -4,6 +4,10 @@ import "FTPserver/Replies"
 
 type NotImplemented struct{}
 
-func (ni NotImplemented) Execute(args string) Replies.FTPReply {
+func (ni NotImplemented) Execute(_ string) Replies.FTPReply {
 	return Replies.CreateReplyCommandNotImplemented()
+}
+
+func (ni NotImplemented) Name() string {
+	return "NotImplemented"
 }

--- a/Commands/PASS.go
+++ b/Commands/PASS.go
@@ -50,3 +50,7 @@ func (cmd PASS) Execute(args string) Replies.FTPReply {
 	}
 	return Replies.CreateReplyNotLoggedIn()
 }
+
+func (cmd PASS) Name() string {
+	return "PASS"
+}

--- a/Commands/PASV.go
+++ b/Commands/PASV.go
@@ -48,3 +48,7 @@ func (cmd PASV) Execute(_ string) Replies.FTPReply {
 	cmd.cs.DataConnection = dataConnection
 	return Replies.CreateReplyEnteringPassiveMode(cmd.cs.DataConnection.PassiveListener.Addr())
 }
+
+func (cmd PASV) Name() string {
+	return "PASV"
+}

--- a/Commands/PBSZ.go
+++ b/Commands/PBSZ.go
@@ -13,7 +13,7 @@ type PBSZ struct {
 
 func (cmd PBSZ) Execute(args string) Replies.FTPReply {
 	// only TLS, a streaming system, is supported so only size 0 will work
-	if !cmd.cs.Security.IsSecure {
+	if !cmd.cs.Security.SecureCommandChannel {
 		return Replies.CreateReplyBadCommandSequence()
 	}
 	size, err := strconv.Atoi(args)
@@ -26,4 +26,8 @@ func (cmd PBSZ) Execute(args string) Replies.FTPReply {
 		reply.Message = "PBSZ=0"
 	}
 	return reply
+}
+
+func (cmd PBSZ) Name() string {
+	return "PBSZ"
 }

--- a/Commands/PORT.go
+++ b/Commands/PORT.go
@@ -56,3 +56,7 @@ func (cmd PORT) Execute(args string) Replies.FTPReply {
 	cmd.cs.DataConnection = dataConnection
 	return Replies.CreateReplyCommandOkay()
 }
+
+func (cmd PORT) Name() string {
+	return "PORT"
+}

--- a/Commands/PROT.go
+++ b/Commands/PROT.go
@@ -10,6 +10,9 @@ type PROT struct {
 }
 
 func (cmd PROT) Execute(args string) Replies.FTPReply {
+	if cmd.cs.LastCommand != "PBSZ" || !cmd.cs.Security.SecureCommandChannel {
+		return Replies.CreateReplyBadCommandSequence()
+	}
 	var dataLevelProtection Connection.DataChannelProtectionLevel
 	switch args {
 	case "C":
@@ -38,4 +41,8 @@ func (cmd PROT) Execute(args string) Replies.FTPReply {
 	}
 	cmd.cs.Security.ProtectionLevel = dataLevelProtection
 	return Replies.CreateReplyCommandOkay()
+}
+
+func (cmd PROT) Name() string {
+	return "PROT"
 }

--- a/Commands/PWD.go
+++ b/Commands/PWD.go
@@ -12,3 +12,7 @@ type PWD struct {
 func (cmd PWD) Execute(_ string) Replies.FTPReply {
 	return Replies.CreateReplyPathnameCreated(cmd.cs.CurrentPath, false)
 }
+
+func (cmd PWD) Name() string {
+	return "PWD"
+}

--- a/Commands/QUIT.go
+++ b/Commands/QUIT.go
@@ -11,8 +11,12 @@ type QUIT struct {
 	cs *Connection.Status
 }
 
-func (cmd QUIT) Execute(args string) Replies.FTPReply {
+func (cmd QUIT) Execute(_ string) Replies.FTPReply {
 	cmd.cs.Disconnect()
 	_, _ = fmt.Fprintln(os.Stderr, "Disconnecting")
 	return Replies.CreateReplyClosingControlConnection("Goodbye")
+}
+
+func (cmd QUIT) Name() string {
+	return "QUIT"
 }

--- a/Commands/RETR.go
+++ b/Commands/RETR.go
@@ -40,3 +40,7 @@ func (cmd RETR) Execute(args string) Replies.FTPReply {
 	}
 	return Replies.CreateReplyClosingDataConnection()
 }
+
+func (cmd RETR) Name() string {
+	return "RETR"
+}

--- a/Commands/RMD.go
+++ b/Commands/RMD.go
@@ -22,3 +22,7 @@ func (cmd RMD) Execute(args string) Replies.FTPReply {
 	}
 	return Replies.CreateReplyCommandOkay()
 }
+
+func (cmd RMD) Name() string {
+	return "RMD"
+}

--- a/Commands/RNFR.go
+++ b/Commands/RNFR.go
@@ -24,3 +24,7 @@ func (cmd RNFR) Execute(args string) Replies.FTPReply {
 	cmd.cs.SetCommands(map[string]bool{"RNTO": true})
 	return Replies.CreateReplyPendingFurtherInformation()
 }
+
+func (cmd RNFR) Name() string {
+	return "RNFR"
+}

--- a/Commands/RNTO.go
+++ b/Commands/RNTO.go
@@ -36,3 +36,7 @@ func (cmd RNTO) Execute(args string) Replies.FTPReply {
 	}
 	return Replies.CreateReplyCommandOkay()
 }
+
+func (cmd RNTO) Name() string {
+	return "RNTO"
+}

--- a/Commands/SITE.go
+++ b/Commands/SITE.go
@@ -25,3 +25,7 @@ func (cmd SITE) Execute(argString string) Replies.FTPReply {
 	}
 	return siteCommand.Execute(argString)
 }
+
+func (cmd SITE) Name() string {
+	return "SITE"
+}

--- a/Commands/STAT.go
+++ b/Commands/STAT.go
@@ -56,3 +56,7 @@ func (cmd STAT) Execute(args string) Replies.FTPReply {
 	}
 	return ExecuteSystem(cmd.cs, cmd.config)
 }
+
+func (cmd STAT) Name() string {
+	return "STAT"
+}

--- a/Commands/STOR.go
+++ b/Commands/STOR.go
@@ -57,3 +57,7 @@ func (cmd STOR) Execute(args string) Replies.FTPReply {
 	}
 	return Replies.CreateReplyClosingDataConnection()
 }
+
+func (cmd STOR) Name() string {
+	return "STOR"
+}

--- a/Commands/STRU.go
+++ b/Commands/STRU.go
@@ -37,3 +37,7 @@ func (cmd STRU) Execute(args string) Replies.FTPReply {
 	}
 	return Replies.CreateReplyCommandNotImplementedForParameter()
 }
+
+func (cmd STRU) Name() string {
+	return "STRU"
+}

--- a/Commands/SYST.go
+++ b/Commands/SYST.go
@@ -16,3 +16,7 @@ func (cmd SYST) Execute(_ string) Replies.FTPReply {
 	}
 	return Replies.CreateReplyNameSystemType(system)
 }
+
+func (cmd SYST) Name() string {
+	return "SYST"
+}

--- a/Commands/TYPE.go
+++ b/Commands/TYPE.go
@@ -50,3 +50,7 @@ func (cmd TYPE) Execute(args string) Replies.FTPReply {
 	}
 	return Replies.CreateReplySyntaxErrorInParameters()
 }
+
+func (cmd TYPE) Name() string {
+	return "TYPE"
+}

--- a/Commands/USER.go
+++ b/Commands/USER.go
@@ -33,3 +33,7 @@ func (cmd USER) Execute(args string) Replies.FTPReply {
 	cmd.cs.SetCommands(map[string]bool{"PASS": true})
 	return Replies.CreateReplyNeedPassword()
 }
+
+func (cmd USER) Name() string {
+	return "USER"
+}

--- a/Commands/Undefined.go
+++ b/Commands/Undefined.go
@@ -7,3 +7,7 @@ type Undefined struct{}
 func (ud Undefined) Execute(_ string) Replies.FTPReply {
 	return Replies.CreateReplyCommandNotImplementedSuperfluous()
 }
+
+func (ud Undefined) Name() string {
+	return "Undefined"
+}

--- a/Configuration/ConfigurationParameters.go
+++ b/Configuration/ConfigurationParameters.go
@@ -26,4 +26,5 @@ type FTPConfig struct {
 	IdleTimeout         int
 	AuthCertFile        string
 	AuthKeyFile         string
+	CCCStatus           Connection.CCCStatus
 }

--- a/Connection/ConnectionStatus.go
+++ b/Connection/ConnectionStatus.go
@@ -44,10 +44,12 @@ func (tm TransferMode) String() string {
 }
 
 type Status struct {
+	LastCommand        string
 	Connected          bool
 	CommandConnection  net.Conn
 	TextProto          *textproto.Conn
 	StandardConnection net.Conn
+	StandardTextProto  *textproto.Conn
 	DataConnected      bool
 	DataConnection     DataConnection
 	Remote             string

--- a/Connection/DataConnection.go
+++ b/Connection/DataConnection.go
@@ -74,7 +74,7 @@ func (dc *DataConnection) FinishSetup() error {
 		if err != nil {
 			return err
 		}
-		if dc.Security.IsSecure {
+		if dc.Security.ProtectionLevel == DataChannelProtectionLevel(Private) {
 			dc.Connection = tls.Server(connection, dc.Security.Config)
 		} else {
 			dc.Connection = connection
@@ -91,7 +91,7 @@ func (dc *DataConnection) FinishSetup() error {
 		if err != nil {
 			return err
 		}
-		if dc.Security.IsSecure && dc.Security.ProtectionLevel == DataChannelProtectionLevel(Private) {
+		if dc.Security.ProtectionLevel == DataChannelProtectionLevel(Private) {
 			dc.Connection = tls.Server(connection, dc.Security.Config)
 		} else {
 			dc.Connection = connection

--- a/Connection/Security.go
+++ b/Connection/Security.go
@@ -2,7 +2,6 @@ package Connection
 
 import (
 	"crypto/tls"
-	"net"
 	"net/textproto"
 )
 
@@ -15,15 +14,23 @@ const (
 	Private
 )
 
+type CCCStatus int
+
+const (
+	Forbid = iota
+	Allow
+)
+
 type Security struct {
-	IsSecure          bool
-	CommandConnection net.Conn
-	TextProto         *textproto.Conn
-	Certificate       tls.Certificate
-	Config            *tls.Config
-	CertFile          string
-	KeyFile           string
-	ProtectedBSize    int
-	ProtectionLevel   DataChannelProtectionLevel
-	SecurityMechanism SecurityMechanism
+	SecureCommandChannel bool
+	CommandConnection    *tls.Conn
+	TextProto            *textproto.Conn
+	Certificate          tls.Certificate
+	Config               *tls.Config
+	CertFile             string
+	KeyFile              string
+	ProtectedBSize       int
+	ProtectionLevel      DataChannelProtectionLevel
+	SecurityMechanism    SecurityMechanism
+	CCCStatus            CCCStatus
 }

--- a/Replies/Replies.go
+++ b/Replies/Replies.go
@@ -394,7 +394,7 @@ func CreateReplyNeedAccountForStoring() FTPReply {
 	}
 }
 
-func CreateReplyCommandProtectionDenniedPolicy() FTPReply {
+func CreateReplyCommandProtectionDeniedPolicy() FTPReply {
 	return FTPReply{
 		Code:    533,
 		Message: "Command protection level denied for policy reasons",

--- a/main.go
+++ b/main.go
@@ -36,6 +36,7 @@ func main() {
 		IdleTimeout:         60,
 		AuthCertFile:        "sample-cert.pem",
 		AuthKeyFile:         "sample-key.pem",
+		CCCStatus:           Connection.CCCStatus(Connection.Forbid),
 	}
 	ftpConfig.PasswordValidator = Implemntation.AnonymousOnlyValidator{
 		AllowAnonymous: true,


### PR DESCRIPTION
Added the CCC command. This allows transitioning the command channel back to unencrypted after the the AUTH command has been issued. The theoretical use for this is that Firewalls can sniff the FTP channel when it is unencrypted and allow expected ports to go through, while still allowing credentials to be sent over encrypted data. Most free FTP clients do not support the CCC command.

Part of performing this included finding out that that the DataChannelProtectionLevel stays in place. And that it can only be negotiated while the command channel is encrypted. So replacements had to be made to whether those commands are allowed. Also since the PROT command must only immediately follow the PBSZ command I added a check for that. As life has become difficult identifying what the last command issued was, I have added the last command to the Connection. This I accomplished by having commands identify themselves, which was done by implementing the Name() function to the FTPCommand interface. So All commands had to be modified to support this.