### PR TITLE
FTP-5 Added ADAT,MIC,CONF,ENC commands

### DIFF
--- a/Commands/ADAT.go
+++ b/Commands/ADAT.go
@@ -1,0 +1,26 @@
+package Commands
+
+import (
+	"FTPserver/Connection"
+	"FTPserver/Replies"
+	"encoding/base64"
+)
+
+type ADAT struct {
+	cs *Connection.Status
+}
+
+func (cmd ADAT) Execute(args string) Replies.FTPReply {
+	if !cmd.cs.Security.SecureCommandChannel {
+		return Replies.CreateReplyBadCommandSequence()
+	}
+	decodedArgs, err := base64.StdEncoding.DecodeString(args)
+	if err != nil {
+		return Replies.CreateReplySyntaxErrorInParameters()
+	}
+	return cmd.cs.Security.SecurityMechanism.ADAT(decodedArgs)
+}
+
+func (cmd ADAT) Name() string {
+	return "ADAT"
+}

--- a/Commands/CONF.go
+++ b/Commands/CONF.go
@@ -1,0 +1,26 @@
+package Commands
+
+import (
+	"FTPserver/Connection"
+	"FTPserver/Replies"
+	"encoding/base64"
+)
+
+type CONF struct {
+	cs *Connection.Status
+}
+
+func (cmd CONF) Execute(args string) Replies.FTPReply {
+	if !cmd.cs.Security.SecureCommandChannel {
+		return Replies.CreateReplyBadCommandSequence()
+	}
+	decodedArgs, err := base64.StdEncoding.DecodeString(args)
+	if err != nil {
+		return Replies.CreateReplySyntaxErrorInParameters()
+	}
+	return cmd.cs.Security.SecurityMechanism.CONF(decodedArgs)
+}
+
+func (cmd CONF) Name() string {
+	return "CONF"
+}

--- a/Commands/Command.go
+++ b/Commands/Command.go
@@ -54,12 +54,12 @@ func GetCommandMap(cs *Connection.Status, config Configuration.FTPConfig) map[st
 		"LPSV": LPSV{cs: cs},
 
 		// RFC-2228 Command Set
-		"ADAT": NotImplemented{},
+		"ADAT": ADAT{cs: cs},
 		"AUTH": AUTH{cs: cs},
 		"CCC":  CCC{cs: cs},
-		"CONF": NotImplemented{},
-		"ENC":  NotImplemented{},
-		"MIC":  NotImplemented{},
+		"CONF": CONF{cs: cs},
+		"ENC":  ENC{cs: cs},
+		"MIC":  MIC{cs: cs},
 		"PBSZ": PBSZ{cs: cs},
 		"PROT": PROT{cs: cs},
 

--- a/Commands/ENC.go
+++ b/Commands/ENC.go
@@ -1,0 +1,26 @@
+package Commands
+
+import (
+	"FTPserver/Connection"
+	"FTPserver/Replies"
+	"encoding/base64"
+)
+
+type ENC struct {
+	cs *Connection.Status
+}
+
+func (cmd ENC) Execute(args string) Replies.FTPReply {
+	if !cmd.cs.Security.SecureCommandChannel {
+		return Replies.CreateReplyBadCommandSequence()
+	}
+	decodedArgs, err := base64.StdEncoding.DecodeString(args)
+	if err != nil {
+		return Replies.CreateReplySyntaxErrorInParameters()
+	}
+	return cmd.cs.Security.SecurityMechanism.ENC(decodedArgs)
+}
+
+func (cmd ENC) Name() string {
+	return "ENC"
+}

--- a/Commands/MIC.go
+++ b/Commands/MIC.go
@@ -1,0 +1,26 @@
+package Commands
+
+import (
+	"FTPserver/Connection"
+	"FTPserver/Replies"
+	"encoding/base64"
+)
+
+type MIC struct {
+	cs *Connection.Status
+}
+
+func (cmd MIC) Execute(args string) Replies.FTPReply {
+	if !cmd.cs.Security.SecureCommandChannel {
+		return Replies.CreateReplyBadCommandSequence()
+	}
+	decodedArgs, err := base64.StdEncoding.DecodeString(args)
+	if err != nil {
+		return Replies.CreateReplySyntaxErrorInParameters()
+	}
+	return cmd.cs.Security.SecurityMechanism.MIC(decodedArgs)
+}
+
+func (cmd MIC) Name() string {
+	return "MIC"
+}

--- a/Connection/SecurityMechanism.go
+++ b/Connection/SecurityMechanism.go
@@ -1,6 +1,12 @@
 package Connection
 
+import "FTPserver/Replies"
+
 type SecurityMechanism interface {
 	SupportedProtections() []DataChannelProtectionLevel
 	Name() string
+	ADAT(args []byte) Replies.FTPReply
+	MIC(args []byte) Replies.FTPReply
+	ENC(args []byte) Replies.FTPReply
+	CONF(args []byte) Replies.FTPReply
 }

--- a/Connection/SecurityTLS.go
+++ b/Connection/SecurityTLS.go
@@ -1,5 +1,7 @@
 package Connection
 
+import "FTPserver/Replies"
+
 type SecurityTLS struct {
 }
 
@@ -12,4 +14,21 @@ func (sm SecurityTLS) SupportedProtections() []DataChannelProtectionLevel {
 
 func (sm SecurityTLS) Name() string {
 	return "TLS"
+}
+
+func (sm SecurityTLS) ADAT(_ []byte) Replies.FTPReply {
+	// There is no exchange of security data here. Just ignore whatever they sent.
+	return Replies.CreateReplySecurityDataExchangeComplete()
+}
+
+func (sm SecurityTLS) MIC(_ []byte) Replies.FTPReply {
+	return Replies.CreateReplyCommandProtectionNotSupported()
+}
+
+func (sm SecurityTLS) CONF(_ []byte) Replies.FTPReply {
+	return Replies.CreateReplyCommandProtectionNotSupported()
+}
+
+func (sm SecurityTLS) ENC(_ []byte) Replies.FTPReply {
+	return Replies.CreateReplyCommandProtectionNotSupported()
 }


### PR DESCRIPTION
These commands are now implemented with their base level processing. The semantics of each is passed off to the security mechanism. The TLS security mechanism does not support any of these commands itself, and they all return the appropriate "This is not supported by the Security Mechanism" response.