### PR TITLE
FTP-5 Added FEAT command

### DIFF
--- a/Commands/ADAT.go
+++ b/Commands/ADAT.go
@@ -1,6 +1,7 @@
 package Commands
 
 import (
+	"FTPserver/Configuration"
 	"FTPserver/Connection"
 	"FTPserver/Replies"
 	"encoding/base64"
@@ -23,4 +24,12 @@ func (cmd ADAT) Execute(args string) Replies.FTPReply {
 
 func (cmd ADAT) Name() string {
 	return "ADAT"
+}
+
+func (cmd ADAT) IsExtendedCommand(cs *Connection.Status, _ Configuration.FTPConfig) bool {
+	return cs.Security.SecurityMechanism.DiscloseADAT()
+}
+
+func (cmd ADAT) AcceptedArguments(_ *Connection.Status, _ Configuration.FTPConfig) []string {
+	return nil
 }

--- a/Commands/AUTH.go
+++ b/Commands/AUTH.go
@@ -1,6 +1,7 @@
 package Commands
 
 import (
+	"FTPserver/Configuration"
 	"FTPserver/Connection"
 	"FTPserver/Replies"
 	"crypto/tls"
@@ -51,4 +52,14 @@ func (cmd AUTH) Execute(args string) Replies.FTPReply {
 
 func (cmd AUTH) Name() string {
 	return "AUTH"
+}
+
+func (cmd AUTH) IsExtendedCommand(_ *Connection.Status, _ Configuration.FTPConfig) bool {
+	return true
+}
+
+func (cmd AUTH) AcceptedArguments(_ *Connection.Status, _ Configuration.FTPConfig) []string {
+	return []string{
+		"TLS",
+	}
 }

--- a/Commands/CCC.go
+++ b/Commands/CCC.go
@@ -1,6 +1,7 @@
 package Commands
 
 import (
+	"FTPserver/Configuration"
 	"FTPserver/Connection"
 	"FTPserver/Replies"
 )
@@ -52,4 +53,12 @@ func (cmd CCC) Execute(_ string) Replies.FTPReply {
 
 func (cmd CCC) Name() string {
 	return "CCC"
+}
+
+func (cmd CCC) IsExtendedCommand(cs *Connection.Status, _ Configuration.FTPConfig) bool {
+	return cs.Security.CCCStatus == Connection.CCCStatus(Connection.Allow)
+}
+
+func (cmd CCC) AcceptedArguments(_ *Connection.Status, _ Configuration.FTPConfig) []string {
+	return nil
 }

--- a/Commands/CONF.go
+++ b/Commands/CONF.go
@@ -1,6 +1,7 @@
 package Commands
 
 import (
+	"FTPserver/Configuration"
 	"FTPserver/Connection"
 	"FTPserver/Replies"
 	"encoding/base64"
@@ -23,4 +24,12 @@ func (cmd CONF) Execute(args string) Replies.FTPReply {
 
 func (cmd CONF) Name() string {
 	return "CONF"
+}
+
+func (cmd CONF) IsExtendedCommand(cs *Connection.Status, _ Configuration.FTPConfig) bool {
+	return cs.Security.SecurityMechanism.DiscloseCONF()
+}
+
+func (cmd CONF) AcceptedArguments(_ *Connection.Status, _ Configuration.FTPConfig) []string {
+	return nil
 }

--- a/Commands/Command.go
+++ b/Commands/Command.go
@@ -64,7 +64,7 @@ func GetCommandMap(cs *Connection.Status, config Configuration.FTPConfig) map[st
 		"PROT": PROT{cs: cs},
 
 		// RFC-2389 Command Set
-		"FEAT": NotImplemented{},
+		"FEAT": FEAT{cs: cs, config: config},
 		"OPTS": NotImplemented{},
 
 		// RFC-2428 Command Set

--- a/Commands/ENC.go
+++ b/Commands/ENC.go
@@ -1,6 +1,7 @@
 package Commands
 
 import (
+	"FTPserver/Configuration"
 	"FTPserver/Connection"
 	"FTPserver/Replies"
 	"encoding/base64"
@@ -23,4 +24,12 @@ func (cmd ENC) Execute(args string) Replies.FTPReply {
 
 func (cmd ENC) Name() string {
 	return "ENC"
+}
+
+func (cmd ENC) IsExtendedCommand(cs *Connection.Status, _ Configuration.FTPConfig) bool {
+	return cs.Security.SecurityMechanism.DiscloseENC()
+}
+
+func (cmd ENC) AcceptedArguments(_ *Connection.Status, _ Configuration.FTPConfig) []string {
+	return nil
 }

--- a/Commands/EPRT.go
+++ b/Commands/EPRT.go
@@ -1,6 +1,7 @@
 package Commands
 
 import (
+	"FTPserver/Configuration"
 	"FTPserver/Connection"
 	"FTPserver/Replies"
 	"fmt"
@@ -98,4 +99,12 @@ func (cmd EPRT) Execute(args string) Replies.FTPReply {
 
 func (cmd EPRT) Name() string {
 	return "EPRT"
+}
+
+func (cmd EPRT) IsExtendedCommand(_ *Connection.Status, _ Configuration.FTPConfig) bool {
+	return true
+}
+
+func (cmd EPRT) AcceptedArguments(_ *Connection.Status, _ Configuration.FTPConfig) []string {
+	return nil
 }

--- a/Commands/EPSV.go
+++ b/Commands/EPSV.go
@@ -1,6 +1,7 @@
 package Commands
 
 import (
+	"FTPserver/Configuration"
 	"FTPserver/Connection"
 	"FTPserver/Replies"
 	"fmt"
@@ -80,4 +81,12 @@ func (cmd EPSV) Execute(args string) Replies.FTPReply {
 
 func (cmd EPSV) Name() string {
 	return "EPSV"
+}
+
+func (cmd EPSV) IsExtendedCommand(_ *Connection.Status, _ Configuration.FTPConfig) bool {
+	return true
+}
+
+func (cmd EPSV) AcceptedArguments(_ *Connection.Status, _ Configuration.FTPConfig) []string {
+	return nil
 }

--- a/Commands/ExtendedCommand.go
+++ b/Commands/ExtendedCommand.go
@@ -1,0 +1,11 @@
+package Commands
+
+import (
+	"FTPserver/Configuration"
+	"FTPserver/Connection"
+)
+
+type ExtendedCommand interface {
+	IsExtendedCommand(status *Connection.Status, config Configuration.FTPConfig) bool
+	AcceptedArguments(status *Connection.Status, config Configuration.FTPConfig) []string
+}

--- a/Commands/FEAT.go
+++ b/Commands/FEAT.go
@@ -1,0 +1,45 @@
+package Commands
+
+import (
+	"FTPserver/Configuration"
+	"FTPserver/Connection"
+	"FTPserver/Replies"
+	"sort"
+	"strings"
+)
+
+type FEAT struct {
+	cs     *Connection.Status
+	config Configuration.FTPConfig
+}
+
+func (cmd FEAT) Execute(_ string) Replies.FTPReply {
+	commandSet := GetCommandMap(cmd.cs, cmd.config)
+	keys := make([]string, 0, len(commandSet))
+	for k := range commandSet {
+		var x interface{} = commandSet[k]
+		command, ok := x.(ExtendedCommand)
+		if ok && command.IsExtendedCommand(cmd.cs, cmd.config) {
+			keys = append(keys, k+" "+strings.Join(command.AcceptedArguments(cmd.cs, cmd.config), ";"))
+		}
+	}
+	sort.Strings(keys)
+	outStr := "Extensions Supported\n"
+	for _, k := range keys {
+		outStr += " " + k + "\n"
+	}
+	outStr += "END"
+	return Replies.CreateReplyHelpMessage(outStr)
+}
+
+func (cmd FEAT) Name() string {
+	return "FEAT"
+}
+
+func (cmd FEAT) IsExtendedCommand(_ *Connection.Status, _ Configuration.FTPConfig) bool {
+	return false
+}
+
+func (cmd FEAT) AcceptedArguments(_ *Connection.Status, _ Configuration.FTPConfig) []string {
+	return nil
+}

--- a/Commands/LPRT.go
+++ b/Commands/LPRT.go
@@ -1,6 +1,7 @@
 package Commands
 
 import (
+	"FTPserver/Configuration"
 	"FTPserver/Connection"
 	"FTPserver/Replies"
 	"fmt"
@@ -134,4 +135,12 @@ func (cmd LPRT) Execute(args string) Replies.FTPReply {
 
 func (cmd LPRT) Name() string {
 	return "LPRT"
+}
+
+func (cmd LPRT) IsExtendedCommand(_ *Connection.Status, _ Configuration.FTPConfig) bool {
+	return true
+}
+
+func (cmd LPRT) AcceptedArguments(_ *Connection.Status, _ Configuration.FTPConfig) []string {
+	return nil
 }

--- a/Commands/LPSV.go
+++ b/Commands/LPSV.go
@@ -1,6 +1,7 @@
 package Commands
 
 import (
+	"FTPserver/Configuration"
 	"FTPserver/Connection"
 	"FTPserver/Replies"
 	"encoding/binary"
@@ -67,4 +68,12 @@ func (cmd LPSV) Execute(_ string) Replies.FTPReply {
 
 func (cmd LPSV) Name() string {
 	return "LPSV"
+}
+
+func (cmd LPSV) IsExtendedCommand(_ *Connection.Status, _ Configuration.FTPConfig) bool {
+	return true
+}
+
+func (cmd LPSV) AcceptedArguments(_ *Connection.Status, _ Configuration.FTPConfig) []string {
+	return nil
 }

--- a/Commands/MIC.go
+++ b/Commands/MIC.go
@@ -1,6 +1,7 @@
 package Commands
 
 import (
+	"FTPserver/Configuration"
 	"FTPserver/Connection"
 	"FTPserver/Replies"
 	"encoding/base64"
@@ -23,4 +24,12 @@ func (cmd MIC) Execute(args string) Replies.FTPReply {
 
 func (cmd MIC) Name() string {
 	return "MIC"
+}
+
+func (cmd MIC) IsExtendedCommand(cs *Connection.Status, _ Configuration.FTPConfig) bool {
+	return cs.Security.SecurityMechanism.DiscloseMIC()
+}
+
+func (cmd MIC) AcceptedArguments(_ *Connection.Status, _ Configuration.FTPConfig) []string {
+	return nil
 }

--- a/Commands/PBSZ.go
+++ b/Commands/PBSZ.go
@@ -1,6 +1,7 @@
 package Commands
 
 import (
+	"FTPserver/Configuration"
 	"FTPserver/Connection"
 	"FTPserver/Replies"
 	"math"
@@ -30,4 +31,12 @@ func (cmd PBSZ) Execute(args string) Replies.FTPReply {
 
 func (cmd PBSZ) Name() string {
 	return "PBSZ"
+}
+
+func (cmd PBSZ) IsExtendedCommand(_ *Connection.Status, _ Configuration.FTPConfig) bool {
+	return true
+}
+
+func (cmd PBSZ) AcceptedArguments(_ *Connection.Status, _ Configuration.FTPConfig) []string {
+	return nil
 }

--- a/Commands/PROT.go
+++ b/Commands/PROT.go
@@ -1,6 +1,7 @@
 package Commands
 
 import (
+	"FTPserver/Configuration"
 	"FTPserver/Connection"
 	"FTPserver/Replies"
 )
@@ -45,4 +46,12 @@ func (cmd PROT) Execute(args string) Replies.FTPReply {
 
 func (cmd PROT) Name() string {
 	return "PROT"
+}
+
+func (cmd PROT) IsExtendedCommand(_ *Connection.Status, _ Configuration.FTPConfig) bool {
+	return true
+}
+
+func (cmd PROT) AcceptedArguments(_ *Connection.Status, _ Configuration.FTPConfig) []string {
+	return nil
 }

--- a/Connection/SecurityMechanism.go
+++ b/Connection/SecurityMechanism.go
@@ -9,4 +9,8 @@ type SecurityMechanism interface {
 	MIC(args []byte) Replies.FTPReply
 	ENC(args []byte) Replies.FTPReply
 	CONF(args []byte) Replies.FTPReply
+	DiscloseADAT() bool
+	DiscloseMIC() bool
+	DiscloseCONF() bool
+	DiscloseENC() bool
 }

--- a/Connection/SecurityTLS.go
+++ b/Connection/SecurityTLS.go
@@ -32,3 +32,18 @@ func (sm SecurityTLS) CONF(_ []byte) Replies.FTPReply {
 func (sm SecurityTLS) ENC(_ []byte) Replies.FTPReply {
 	return Replies.CreateReplyCommandProtectionNotSupported()
 }
+
+func (sm SecurityTLS) DiscloseADAT() bool {
+	return false
+}
+
+func (sm SecurityTLS) DiscloseMIC() bool {
+	return false
+}
+
+func (sm SecurityTLS) DiscloseCONF() bool {
+	return false
+}
+func (sm SecurityTLS) DiscloseENC() bool {
+	return false
+}


### PR DESCRIPTION
Added the FEAT command and new interface for extended commands. This will allow commands to identify if they are featured, and what kind of additional parameters they may allow (e.g. AUTH TLS)

Add commands that are beyond the RFC 959 set have been adapted to support this interface. Commands that do not support this interface are ignore by the FEAT command.

The security options ADAT, MIC, CONF, ENC are left to the security mechanism to determine if they are displayed (because they exist but are not used by TLS auth). And CCC only displays if CCC is enabled.