### PR TITLE
FTP-15 Added OPTS command

### DIFF
--- a/Commands/Command.go
+++ b/Commands/Command.go
@@ -65,7 +65,7 @@ func GetCommandMap(cs *Connection.Status, config Configuration.FTPConfig) map[st
 
 		// RFC-2389 Command Set
 		"FEAT": FEAT{cs: cs, config: config},
-		"OPTS": NotImplemented{},
+		"OPTS": OPTS{cs: cs, config: config},
 
 		// RFC-2428 Command Set
 		"EPRT": EPRT{cs: cs},

--- a/Commands/OPTS.go
+++ b/Commands/OPTS.go
@@ -1,0 +1,39 @@
+package Commands
+
+import (
+	"FTPserver/Commands/OptionsCommands"
+	"FTPserver/Configuration"
+	"FTPserver/Connection"
+	"FTPserver/Replies"
+	"strings"
+)
+
+type OPTS struct {
+	cs     *Connection.Status
+	config Configuration.FTPConfig
+}
+
+func (cmd OPTS) Execute(args string) Replies.FTPReply {
+	splitArgs := strings.SplitN(args, " ", 1)
+	if len(splitArgs) < 1 {
+		return Replies.CreateReplySyntaxErrorInParameters()
+	}
+	command := splitArgs[0]
+	rest := ""
+	if len(splitArgs) > 1 {
+		rest = splitArgs[1]
+	}
+	oCmd, ok := OptionsCommands.GetCommandFunction(command, cmd.cs, cmd.config)
+	if !ok {
+		return Replies.CreateReplySyntaxErrorInParameters()
+	}
+	err := oCmd.OptionsSet(cmd.cs, command, rest)
+	if err != nil {
+		return Replies.CreateReplySyntaxErrorInParameters()
+	}
+	return Replies.CreateReplyCommandOkay()
+}
+
+func (cmd OPTS) Name() string {
+	return "OPTS"
+}

--- a/Commands/OptionsCommands/OptionsCommand.go
+++ b/Commands/OptionsCommands/OptionsCommand.go
@@ -1,0 +1,20 @@
+package OptionsCommands
+
+import (
+	"FTPserver/Configuration"
+	"FTPserver/Connection"
+)
+
+type OptionsCommand interface {
+	OptionsSet(status *Connection.Status, command string, args string) error
+}
+
+func GetCommandMap(cs *Connection.Status, config Configuration.FTPConfig) map[string]OptionsCommand {
+	return map[string]OptionsCommand{}
+}
+
+func GetCommandFunction(command string, cs *Connection.Status, config Configuration.FTPConfig) (OptionsCommand, bool) {
+	commandMap := GetCommandMap(cs, config)
+	cmd, ok := commandMap[command]
+	return cmd, ok
+}

--- a/Connection/ConnectionStatus.go
+++ b/Connection/ConnectionStatus.go
@@ -1,6 +1,7 @@
 package Connection
 
 import (
+	"FTPserver/Options"
 	"FTPserver/Replies"
 	"fmt"
 	"net"
@@ -71,6 +72,7 @@ type Status struct {
 	PreferredEProtocol int
 	EPSVAll            bool
 	Security           Security
+	Options            Options.Options
 }
 
 func (cs *Status) Connect() {

--- a/Options/Options.go
+++ b/Options/Options.go
@@ -1,0 +1,4 @@
+package Options
+
+type Options struct {
+}


### PR DESCRIPTION
Added support for the OPTS command. None of the existing commands support options, so this doesn't actually do much. This will probably have to be revised as it looks like there are new commands that are official commands that will use options, and there are commands that offer no value, but do have options. If they are real commands they will have to be retrievable by the Command Map, but if they are not "real" commands, they will don't have to be, but they probably should.